### PR TITLE
Revert "Bump blampe/lidarr from lidarr-plugins-2.12.3.4655 to lidarr-plugins-2.13.0.4661 in /docker-infra/home"

### DIFF
--- a/docker-infra/home/docker-compose.yml
+++ b/docker-infra/home/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - beets-secret-config
 
   lidarr:
-    image: blampe/lidarr:lidarr-plugins-2.13.0.4661
+    image: blampe/lidarr:lidarr-plugins-2.12.3.4655
     restart: unless-stopped
     environment:
       PUID: 1000


### PR DESCRIPTION
Reverts vganin/vsevolodganin.com#17