### PR TITLE
Revert "Bump jonasal/nginx-certbot from 5.5.0-nginx1.27.5-alpine to 5.6.0-nginx1.27.5-alpine in /docker-infra/home"

### DIFF
--- a/docker-infra/home/docker-compose.yml
+++ b/docker-infra/home/docker-compose.yml
@@ -141,7 +141,7 @@ services:
       - ${HDD_PATH:?error}/downloads/pyload:/downloads
 
   nginx:
-    image: jonasal/nginx-certbot:5.6.0-nginx1.27.5-alpine
+    image: jonasal/nginx-certbot:5.5.0-nginx1.27.5-alpine
     depends_on:
       - filebrowser
       - navidrome


### PR DESCRIPTION
Reverts vganin/vsevolodganin.com#10